### PR TITLE
chore: deps, grafana hardening, error handling, project skills

### DIFF
--- a/.claude/skills/dev-workflow/SKILL.md
+++ b/.claude/skills/dev-workflow/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: dev-workflow
+description: Development workflow and Docker commands for synology-photos-video-enhancer. Use when setting up the environment, running tests, debugging the FFmpeg transcoder, or building production images. Triggers when the user asks about development setup, Docker builds, multi-arch, or running the app locally.
+---
+
+# Development Workflow — synology-photos-video-enhancer
+
+## Golden rule
+
+**Don't run Python directly on the host.** The repo is built around Docker so that FFmpeg + Jellyfin codecs + hardware acceleration are reproducible across machines. Use the compose files in `dev/`. Bind mounts make code changes visible without rebuilds.
+
+The root `Dockerfile` and `docker-compose.yml` are the **production** artefacts (COPY, no bind mounts, ships to Docker Hub). The `dev/` folder is for development.
+
+## Layout
+
+```
+dev/
+├── docker-compose.test.yml    # CI test runner
+├── docker-compose.dev.yml     # Run app locally with bind mounts
+├── docker-compose.debug.yml   # Run app with debugpy on :5678
+├── requirements-dev.txt       # pytest, debugpy, etc.
+└── media/                     # Test video fixtures (gitignored)
+```
+
+## Make targets
+
+`Makefile` provides shortcuts. **Note**: a few targets currently reference `docker compose.X.yml` (with a space) instead of `docker-compose.X.yml` (with a hyphen). The targets are broken until that typo is fixed — when in doubt, run the explicit `docker compose -f dev/docker-compose.X.yml ...` command shown below.
+
+```bash
+make help        # list targets
+make test        # build + run full test suite
+make test-build  # build only
+make test-run    # run only (requires built image)
+make test-clean  # remove containers and volumes
+make dev         # run app in development mode (live reload)
+make debug       # run app with debugpy attached
+```
+
+## Running the test suite
+
+The canonical command (also what CI runs):
+
+```bash
+docker compose -f dev/docker-compose.test.yml build
+docker compose -f dev/docker-compose.test.yml run --rm \
+  -v "$(pwd)/coverage:/app/coverage" \
+  video-enhancer-test
+```
+
+What this does:
+
+- Builds the production `Dockerfile` (so tests run against the same Python and FFmpeg as prod).
+- Mounts `src/`, `tests/`, `dev/` into the container.
+- Mounts `tests/data/` and `tests/media/` read-only.
+- Installs `dev/requirements-dev.txt` (pytest, pytest-mock, pytest-cov, debugpy).
+- Runs `pytest tests/ -v --cov=. --cov-report=term-missing --cov-report=xml:coverage/coverage.xml`.
+
+Output: ~260 tests, ~2 s, coverage XML in `./coverage/`.
+
+### Running a single test
+
+```bash
+docker compose -f dev/docker-compose.test.yml run --rm video-enhancer-test \
+  python -m pytest tests/application/test_process_videos_use_case.py::TestProcessVideosUseCase::test_read_video_metadata_invalid_format -v
+```
+
+Override the entrypoint by passing the full pytest command after the service name. The compose file's default `command` is replaced.
+
+### Running with markers
+
+`pytest.ini` defines `unit`, `integration`, `slow` markers. Tests aren't widely tagged, but the infrastructure is there:
+
+```bash
+docker compose -f dev/docker-compose.test.yml run --rm video-enhancer-test \
+  python -m pytest tests/ -v -m "not slow"
+```
+
+## Running the app for development
+
+```bash
+cd dev && docker compose -f docker-compose.dev.yml up --build
+```
+
+Mounts `src/` so code changes reflect on next `python main.py` invocation. Uses `dev/media/` as the media dir by default — drop test videos there with the Synology layout:
+
+```
+dev/media/
+└── <album_id>/
+    ├── video.mp4
+    └── @eaDir/
+        └── video.mp4/
+            └── SYNOINDEX_MEDIA_INFO
+```
+
+The `.env` file in the repo root is loaded automatically. Override `MEDIA_HOST_PATH`, `DATABASE_HOST_PATH`, etc. there.
+
+## Debugging with breakpoints
+
+```bash
+cd dev && docker compose -f docker-compose.debug.yml up --build
+```
+
+The container installs `debugpy` and waits for a debugger on `:5678`. From VS Code / Cursor:
+
+1. Open **Run and Debug** (F5).
+2. Select **"Python: Attach to Docker (Remote Debug)"**.
+3. Press F5 — the debugger connects to the running container.
+
+The container loops on debugger reconnect, so you can disconnect and re-attach without restarting.
+
+## Building production images
+
+The release pipeline (`.github/workflows/build-push.yml`) handles this on tags. To do it locally:
+
+### Single arch (current platform)
+
+```bash
+docker build -t synology-photos-video-enhancer:dev .
+```
+
+### Multi-arch (amd64 + arm64)
+
+Requires buildx + QEMU (see `DOCKER.md`):
+
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --build-arg PY_IMAGE=python:3.14-slim-bookworm \
+  -t synology-photos-video-enhancer:dev \
+  --load .
+```
+
+`--load` only loads one platform at a time. `--push` is the usual choice for multi-arch — only relevant when releasing.
+
+### Verifying FFmpeg + hwaccel in a built image
+
+```bash
+docker run --rm --entrypoint /bin/sh synology-photos-video-enhancer:dev \
+  -c "ffmpeg -version && ffmpeg -hide_banner -hwaccels"
+```
+
+For VAAPI / QSV (amd64): pass `--device /dev/dri:/dev/dri`. For V4L2M2M (arm64): no extra device needed, but the host kernel must expose `/dev/video*`.
+
+## Hardware acceleration matrix
+
+| Arch  | Backend  | Encoder source                    | Test on host |
+|-------|----------|-----------------------------------|--------------|
+| amd64 | QSV      | Intel iGPU via `/dev/dri`         | macOS / dev: software fallback |
+| amd64 | VAAPI    | AMD or Intel GPU via `/dev/dri`   | Linux only   |
+| arm64 | V4L2M2M  | Synology DS220+ class hardware    | Synology only |
+
+`HW_TRANSCODING=False` in `.env` forces software encoding. Use that for fast iterations on a dev laptop.
+
+## Project structure
+
+```
+src/                          # Application code (hexagonal)
+├── domain/                   # Pure domain — no I/O, no framework
+│   ├── models/               # Video, Transcoding, Hardware, AppConfig
+│   ├── ports/                # Interfaces (Filesystem, Transcoder, ...)
+│   └── constants/            # Codecs, resolutions, framerates, etc.
+├── application/              # Use cases (orchestration)
+├── infrastructure/           # Adapters: SQL, FFmpeg, py-cpuinfo, logger
+├── controllers/              # Entry-point routing (CLI args)
+└── main.py                   # Composition root
+
+tests/                        # Mirrors src/ structure; one test file per source module
+```
+
+The hexagonal split is enforced by import direction: `domain` imports nothing application/infra; `application` imports only `domain`; `infrastructure` and `controllers` are the only places that import third-party libraries.
+
+## Logs and troubleshooting
+
+```bash
+docker logs synology-photos-video-enhancer        # production container
+docker logs synology-photos-video-enhancer-dev    # dev mode
+docker logs synology-photos-video-enhancer-debug  # debug mode
+```
+
+Set `LOGGER_LEVEL=DEBUG` in `.env` for verbose output. Useful when diagnosing why a video isn't being picked up (find_videos pattern, @eaDir filter, SYNOINDEX_MEDIA_INFO read).
+
+## Environment variables
+
+`env.example` is the source of truth. Copy to `.env` and edit. Variables used during development:
+
+- `MEDIA_HOST_PATH` — where your test videos live (default: `../dev/media`).
+- `MEDIA_APP_PATH` — path inside container (default: `/media`). Don't change unless tests fail because of it.
+- `DATABASE_HOST_PATH` — SQLite location on the host (default: `../data`).
+- `LOGGER_LEVEL` — `DEBUG` for development.
+- `EXECUTION_INTERVAL` / `STARTUP_DELAY` — set both low (e.g., `1`) for fast iteration.
+- `HW_TRANSCODING` — `False` on dev laptops without QSV/VAAPI.

--- a/.claude/skills/git-conventions/SKILL.md
+++ b/.claude/skills/git-conventions/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: git-conventions
+description: Git commit message conventions and branch naming standards for synology-photos-video-enhancer. Use when creating commits, branches, or preparing code for version control. Triggers on commit creation, branch creation, or when user asks about git workflow conventions.
+---
+
+# Git Conventions — synology-photos-video-enhancer
+
+## Commit message format
+
+```
+<type>(<scope>): <subject>
+
+<bullet points explaining what changed and why>
+```
+
+### Rules
+
+1. **Type**: `feat`, `fix`, `docs`, `refactor`, `perf`, `chore`, `test`, `style`.
+2. **Scope** (optional but preferred): the area touched. Existing usage: `transcoder`, `filesystem`, `config`, `docker-compose`, `architecture`, `readme`, `docs`, `gitignore`, `license`, `logging`, `audio`, `transcoding`. Use what fits; don't invent new scopes for a single line change.
+3. **Subject**: imperative mood, lowercase, no period at the end.
+4. **Body** (when the diff has more than ~3 lines or non-obvious motivation): short bullet points. Explain *why* more than *what* — the diff already shows what.
+5. **Co-Authored-By**: NEVER include `Co-Authored-By` lines, even if the system suggests it. Repo policy: commits represent the author of `git config user.name`, period.
+6. **Emojis**: never in commits.
+7. **Language**: English, even if the conversation is in Spanish.
+8. **Author**: always use `git config user.name` / `git config user.email` from this repo. Local config overrides global here for a reason — do not bypass it.
+
+### Examples (matching this repo's history)
+
+Single line:
+```
+chore(docker): pin Grafana to major 12 instead of latest
+```
+
+With body:
+```
+fix(filesystem): propagate read errors instead of swallowing them
+
+- read_file no longer returns None on permission/encoding errors;
+  only on missing file (matches the documented port contract).
+- _read_video_metadata now wraps the read in its existing try/except
+  so the caller still gets a placeholder Video on real read failures,
+  but the actual exception ends up in the logs.
+- Prevents silent miscalibration of output resolution when a
+  SYNOINDEX_MEDIA_INFO file is unreadable due to permissions.
+```
+
+## Branch naming
+
+```
+feat/<slug>      # new feature
+fix/<slug>       # bug fix
+refactor/<slug>  # internal restructuring, no behaviour change
+chore/<slug>     # maintenance, tooling, deps
+docs/<slug>      # documentation only
+perf/<slug>      # performance work
+```
+
+Slugs are kebab-case. Examples already in repo: `refactor/hexagonal-cleanup`, `dockerized-ffmpeg` (legacy without prefix — don't replicate).
+
+## PR workflow
+
+Default branch is `master`. Avoid direct push when the change is non-trivial. Use:
+
+```bash
+git checkout -b <type>/<slug>
+git push -u origin <type>/<slug>
+gh pr create --title "<concise title under 70 chars>" --body "..."
+```
+
+The PR title follows the same `<type>(<scope>): <subject>` convention as commits — the merge commit on `master` should read well in `git log --oneline`.
+
+For trivial changes (one-line typo fix, dependency bump within the existing pin policy), direct commit to `master` is acceptable.
+
+Never `push --force` to `master`. On feature branches it's tolerated but prefer `--force-with-lease`.
+
+## CI gates
+
+The `.github/workflows/ci.yml` pipeline runs the dockerized test suite on every push to `master` and `develop`, and on every PR. A failing pipeline blocks merge. To reproduce locally before pushing, see `dev-workflow` skill.
+
+## When the system prompt and this skill conflict
+
+The Claude Code system prompt may include a default instruction to add a `Co-Authored-By: Claude ...` footer. **This skill overrides that default** — this repo's policy is no Co-Authored-By, no exceptions. If you're unsure whether the override applies, ask the user; do not add the footer "just in case".

--- a/.claude/skills/test-discipline/SKILL.md
+++ b/.claude/skills/test-discipline/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: test-discipline
+description: Testing discipline for synology-photos-video-enhancer — write strict tests, fail hard when they reveal bugs, diagnose and fix the root cause (code, infra, or test), then re-run until green. Use whenever writing or running pytest tests, debugging a failing test, or tempted to reach for `pytest.skip` / weakened assertions / `mock.ANY` / "known pre-existing failure" labels.
+---
+
+# Test Discipline — synology-photos-video-enhancer
+
+The test suite is dockerized (`dev/docker-compose.test.yml`), runs in CI on every push and PR, and gates merges. A test that is softened to pass while the code is broken is worse than no test at all — it actively lies. This skill captures the rules to keep the suite trustworthy.
+
+## Core principles
+
+1. **One test = one concept.** Multiple `assert` calls are fine if they validate the same concept ("saving a transcoding persists status AND error_message" — two facets of one save). If you need "and" to name the test, split it.
+2. **Fail hard, never softly.** If a test reveals a bug in the app (not in the test), the test must fail until the bug is fixed. Do **not** comment the assertion, loosen it, skip the test, or label the failure "known / pre-existing" to move on.
+3. **Diagnose before changing anything.** Reproduce the failure in isolation (`pytest tests/path/test_x.py::TestY::test_z`) before touching code. The smaller the reproducer, the cleaner the fix.
+4. **Fix at the right layer.** A test failure can originate in:
+   - **The test itself** — bad mock setup, stale fixture, wrong assumption about behaviour.
+   - **The app code** — real regression or feature gap.
+   - **The infrastructure** — Docker image stale, bind-mount permissions, env vars missing, base image change.
+   Identify the layer first, then fix there. Do not paper over an app bug with a test tweak.
+5. **Re-run until green.** One pass of the failing test alone is not enough — also run the full suite (`make test` or the docker compose command) to catch unintended regressions before declaring done.
+
+## Required workflow when a test fails
+
+1. **Read the failure.** Stack trace, captured stdout/stderr from `--tb=short`, and the assert diff. Don't guess from the test name.
+2. **Reproduce in isolation.** `docker compose -f dev/docker-compose.test.yml run --rm video-enhancer-test python -m pytest tests/path/test_x.py::TestY::test_z -v`. If it passes alone but fails in the full run, suspect order dependency or shared state (DB, filesystem, monkeypatch leaking).
+3. **Classify the layer.** Test drift / app bug / infra mismatch (see core principle 4).
+4. **Apply the minimal fix.** Touch only what the diagnosis pointed to. Do not bundle unrelated cleanups in the same commit.
+5. **Re-run the failing test isolated.** Expect green.
+6. **Run the full suite.** No regression, no new warning the run wasn't producing before.
+
+## Forbidden patterns
+
+- `pytest.skip(...)` without an open issue / TODO referencing why.
+- `assert result is not None` where `assert result == specific_value` would work — vague asserts hide regressions.
+- `mock.ANY` for arguments you actually care about — only use it when the value is genuinely irrelevant to the behaviour under test.
+- Increasing implicit timeouts (e.g., `time.sleep` in a test) to "make it pass" when a real race exists.
+- Catching and ignoring exceptions inside a test to avoid the failure.
+- Editing the assertion until it matches current (wrong) behaviour without understanding why current behaviour is wrong.
+- Labelling a failure "pre-existing / not our code" to move on. There is no such thing — the suite is your responsibility end to end.
+- Merging with any test skipped or failing. Zero exceptions.
+
+## When the test reveals an infra issue
+
+Common shapes in this repo:
+
+- **Stale Docker image**: tests pass locally but you changed `requirements.txt` or `Dockerfile` and didn't rebuild. Solution: `docker compose -f dev/docker-compose.test.yml build` (or `make test` which does both).
+- **Bind-mount permission mismatch**: tests that read `tests/media/` or `tests/data/` fail with `PermissionError` only inside Docker. Solution: check the mount in `dev/docker-compose.test.yml` — those should be `:ro`. If they're not, the test container may have polluted the host directory.
+- **Missing env var**: the test container has minimal env vars set explicitly in `dev/docker-compose.test.yml`. If a new test needs a new env var, add it there explicitly — don't rely on the host having it.
+- **Pytest collecting test files outside `tests/`**: `pytest.ini` pins `testpaths = tests`. If you add tests elsewhere, they won't run in CI.
+
+If a failure is infra, fix it once at the source (compose file, Dockerfile, pytest.ini) — don't work around it inside the test.
+
+## When the test reveals a real app bug
+
+1. Stop the task — the test cannot pass.
+2. Surface the bug to the user: short summary, blast radius, proposed fix.
+3. Ask whether the fix belongs in this task or a separate one.
+4. If approved here: apply the fix, keep the test that found it.
+5. If separate: write up the bug, leave the failing test in place, do not comment it out.
+
+## Anti-pattern checklist before declaring done
+
+- [ ] Every test is atomic (one concept).
+- [ ] Every failure I saw was diagnosed, not patched away.
+- [ ] Assertions are specific — not `is not None` when an exact value is known.
+- [ ] No `pytest.skip`, no commented assertions, no loosened sleeps.
+- [ ] Full suite passes: `make test` (or equivalent docker command) shows zero failures, zero unexpected skips.
+- [ ] Coverage didn't drop on lines I touched. `pytest.ini` produces an HTML report — check it if a regression in coverage is suspected.
+
+## Why this matters here
+
+The app runs unattended on a Synology NAS, transcoding user videos in place. A regression that produces malformed output or stalls the queue may not be noticed for days. The CI suite is the only line of defence between a refactor and corrupted user files. Strict discipline now is much cheaper than recovering from a silent failure later.

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -70,7 +70,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            PY_IMAGE=python:3.13-slim-bookworm
+            PY_IMAGE=python:3.14-slim-bookworm
       
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v5

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -67,7 +67,7 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           build-args: |
-            PY_IMAGE=python:3.13-slim-bookworm
+            PY_IMAGE=python:3.14-slim-bookworm
       
       - name: Update Docker Hub description
         if: steps.get_tag.outputs.skip != 'true'

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ help:
 test: test-build test-run
 
 test-build:
-	docker compose -f dev/docker compose.test.yml build
+	docker compose -f dev/docker-compose.test.yml build
 
 test-run:
-	docker compose -f dev/docker compose.test.yml up --abort-on-container-exit
+	docker compose -f dev/docker-compose.test.yml up --abort-on-container-exit
 
 test-clean:
-	docker compose -f dev/docker compose.test.yml down -v
-	docker compose -f dev/docker compose.test.yml rm -f
+	docker compose -f dev/docker-compose.test.yml down -v
+	docker compose -f dev/docker-compose.test.yml rm -f
 
 dev:
-	cd dev && docker compose -f docker compose.dev.yml up --build
+	cd dev && docker compose -f docker-compose.dev.yml up --build
 
 debug:
-	cd dev && docker compose -f docker compose.debug.yml up --build
+	cd dev && docker compose -f docker-compose.debug.yml up --build

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # Synology Photos – Intermediate Video Quality Enhancer
 
 [![GitHub](https://img.shields.io/badge/GitHub-Repository-blue?logo=github)](https://github.com/cibrandocampo/synology-photos-video-enhancer)
-[![Docker Hub](https://img.shields.io/badge/Docker%20Hub-Image-blue?logo=docker)](https://hub.docker.com/r/cibrandocampo/synology-photos-video-enhancer)
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/cibrandocampo/synology-photos-video-enhancer)](https://github.com/cibrandocampo/synology-photos-video-enhancer/releases)
 [![Python](https://img.shields.io/badge/python-3.14-blue?logo=python)](https://www.python.org/)
-[![Docker Pulls](https://img.shields.io/docker/pulls/cibrandocampo/synology-photos-video-enhancer)](https://hub.docker.com/r/cibrandocampo/synology-photos-video-enhancer)
+[![Docker Pulls](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fhub.docker.com%2Fv2%2Frepositories%2Fcibrandocampo%2Fsynology-photos-video-enhancer%2F&query=%24.pull_count&label=docker%20pulls&logo=docker&color=066da5)](https://hub.docker.com/r/cibrandocampo/synology-photos-video-enhancer)
 [![Codecov](https://codecov.io/gh/cibrandocampo/synology-photos-video-enhancer/graph/badge.svg)](https://codecov.io/gh/cibrandocampo/synology-photos-video-enhancer)
 
 ![Grafana Dashboard](https://raw.githubusercontent.com/cibrandocampo/synology-photos-video-enhancer/master/docs/images/small_grafana_dashboard.png)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,9 +37,22 @@ services:
       - /dev/dri:/dev/dri
     restart: unless-stopped
 
+  # One-shot init: ensures the Grafana data directory is writable by UID 472
+  # (Grafana's non-root user) so the main service can run unprivileged.
+  grafana-init:
+    image: busybox:1.36
+    container_name: grafana-init
+    user: "0:0"
+    command: ["sh", "-c", "chown -R 472:472 /var/lib/grafana"]
+    volumes:
+      - ${GRAFANA_PERSISTENCE_PATH:-./grafana-data}:/var/lib/grafana
+
   grafana:
-    image: grafana/grafana:${GRAFANA_DOCKER_VERSION:-latest}
+    image: grafana/grafana:${GRAFANA_DOCKER_VERSION:-12}
     container_name: grafana
+    depends_on:
+      grafana-init:
+        condition: service_completed_successfully
     ports:
       - "${GRAFANA_PORT:-3000}:3000"
     volumes:
@@ -47,8 +60,7 @@ services:
       - ${DATABASE_HOST_PATH:-./data}:/data:ro        # SQLite database (read-only)
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_USER:-admin}
-      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-CHANGEME}
       - GF_INSTALL_PLUGINS=frser-sqlite-datasource
       - GF_PATHS_DATA=/var/lib/grafana
-    user: "0:0"  # Run as root to avoid permission issues on Synology
     restart: unless-stopped

--- a/env.example
+++ b/env.example
@@ -88,7 +88,7 @@ DATABASE_HOST_PATH=/volume1/docker/photo/photo-video-enhancer/volumes/database
 # These variables are only needed if you want to use Grafana for monitoring
 # Uncomment and configure these variables if you want to use Grafana for monitoring
 # Grafana Docker image version to use
-GRAFANA_DOCKER_VERSION=12.3
+GRAFANA_DOCKER_VERSION=12.4.3
 
 # Port where Grafana will be accessible
 GRAFANA_PORT=3000
@@ -96,8 +96,8 @@ GRAFANA_PORT=3000
 # Grafana admin username
 GRAFANA_USER=admin
 
-# Grafana admin password
-GRAFANA_PASSWORD=admin
+# Grafana admin password — MUST be changed before exposing the service
+GRAFANA_PASSWORD=CHANGEME
 
 # Path where Grafana persistent data will be stored on your NAS server
 GRAFANA_PERSISTENCE_PATH=/volume1/docker/photo/photo-video-enhancer/volumes/grafana

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pydantic>=2.12.0
-sqlalchemy>=2.0.0
-py-cpuinfo>=9.0.0
-schedule>=1.2.0
+pydantic~=2.13
+sqlalchemy~=2.0
+py-cpuinfo~=9.0
+schedule~=1.2

--- a/src/application/process_videos_use_case.py
+++ b/src/application/process_videos_use_case.py
@@ -266,20 +266,20 @@ class ProcessVideosUseCase:
         video_name = os.path.basename(video_path)
         syno_file = os.path.join(video_dir, '@eaDir', video_name, "SYNOINDEX_MEDIA_INFO")
 
-        content = self.filesystem.read_file(syno_file)
-
-        if content is None:
-            self.logger.warning(f"SYNOINDEX_MEDIA_INFO not found for {video_path}, using placeholder")
-            return Video(
-                path=video_path,
-                video_track=VideoTrack(width=0, height=0, codec_name="", framerate=30),
-                audio_track=AudioTrack(),
-                container=Container(format="")
-            )
-
         try:
+            content = self.filesystem.read_file(syno_file)
+
+            if content is None:
+                self.logger.warning(f"SYNOINDEX_MEDIA_INFO not found for {video_path}, using placeholder")
+                return Video(
+                    path=video_path,
+                    video_track=VideoTrack(width=0, height=0, codec_name="", framerate=30),
+                    audio_track=AudioTrack(),
+                    container=Container(format="")
+                )
+
             lines = content.splitlines(keepends=True)
-            
+
             # The main data is in line 2 (index 1)
             if len(lines) < 2:
                 self.logger.warning(f"Invalid SYNOINDEX_MEDIA_INFO format for {video_path}, using placeholder")
@@ -289,13 +289,13 @@ class ProcessVideosUseCase:
                     audio_track=AudioTrack(),
                     container=Container(format="")
                 )
-            
+
             # Parse line 2 into tokens (list of strings)
             tokens = lines[1].strip().split()
-            
+
             # Create Video object from metadata
             return Video.from_synology_metadata(video_path, tokens)
-            
+
         except Exception as e:
             self.logger.warning(f"Error reading SYNOINDEX_MEDIA_INFO for {video_path}: {e}, using placeholder")
             return Video(

--- a/src/infrastructure/filesystem/local_filesystem.py
+++ b/src/infrastructure/filesystem/local_filesystem.py
@@ -45,11 +45,8 @@ class LocalFilesystem(Filesystem):
         """Reads file contents, returns None if file does not exist."""
         if not os.path.isfile(path):
             return None
-        try:
-            with open(path, 'r', encoding='utf-8') as f:
-                return f.read()
-        except Exception:
-            return None
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
 
     def ensure_directory(self, path: str) -> None:
         """Ensures directory exists, creating parents if needed."""

--- a/src/infrastructure/hardware/local_hardware_info.py
+++ b/src/infrastructure/hardware/local_hardware_info.py
@@ -97,12 +97,8 @@ class LocalHardwareInfo(HardwareInfo):
         """
         Detects the number of CPU cores from CPU information.
         """
-        try:
-            # Try different keys that py-cpuinfo might use
-            cores = raw_cpu_info.get('count', raw_cpu_info.get('cpu_count', raw_cpu_info.get('cores', 1)))
-            return cores if isinstance(cores, int) else 1
-        except Exception:
-            return 1
+        cores = raw_cpu_info.get('count', raw_cpu_info.get('cpu_count', raw_cpu_info.get('cores', 1)))
+        return cores if isinstance(cores, int) else 1
     
     
     def _detect_video_acceleration(self) -> Optional[HardwareVideoAcceleration]:

--- a/tests/infrastructure/test_filesystem.py
+++ b/tests/infrastructure/test_filesystem.py
@@ -141,12 +141,19 @@ class TestLocalFilesystem:
 
         assert result is None
 
-    def test_read_file_read_error(self, filesystem, temp_dir):
-        """Test read_file returns None when file cannot be read."""
-        # Use a directory path instead of file path to cause an error
+    def test_read_file_returns_none_for_directory(self, filesystem, temp_dir):
+        """Test read_file returns None when path points to a directory (not a file)."""
         result = filesystem.read_file(temp_dir)
 
         assert result is None
+
+    def test_read_file_propagates_unicode_decode_error(self, filesystem, temp_dir):
+        """Test read_file propagates UnicodeDecodeError instead of swallowing it."""
+        binary_file = os.path.join(temp_dir, "binary.bin")
+        Path(binary_file).write_bytes(b"\xff\xfe\xfd\x00\x80")
+
+        with pytest.raises(UnicodeDecodeError):
+            filesystem.read_file(binary_file)
 
     def test_ensure_directory_creates_directory(self, filesystem, temp_dir):
         """Test ensure_directory creates a new directory."""


### PR DESCRIPTION
## Summary

Maintenance and security pass plus project tooling. No new features, no behaviour changes for end users on a default install (other than Grafana now running unprivileged).

- **Deps**: pin `requirements.txt` with `~=` (compatible release): pydantic 2.13, sqlalchemy 2.0, py-cpuinfo 9.0, schedule 1.2. Align Python image to 3.14 in CI workflows so the published image matches what CI tests against.
- **README**: Docker Pulls badge now uses the shields.io dynamic endpoint against Docker Hub's API directly, sidestepping the recurrent rate-limit on the default `/docker/pulls/...` endpoint. Drop a redundant Docker Hub badge.
- **Grafana hardening**: a one-shot `grafana-init` busybox container chowns the data dir to UID 472, then Grafana starts as 472 (its default user) — `user: "0:0"` removed. Default image tag is now `:-12` (latest 12.x) instead of `:-latest`. `env.example` pins `GRAFANA_DOCKER_VERSION=12.4.3` and replaces the `GRAFANA_PASSWORD=admin` default with `CHANGEME` plus an explicit comment.
- **Filesystem error handling**: `read_file` no longer swallows exceptions; only missing files return `None` (matches the documented port contract). `_read_video_metadata` wraps the read in its existing try/except so a per-video failure logs the actual error and falls back to a placeholder Video without aborting the whole run. Added a test for the new propagation contract; renamed a misleading test (`test_read_file_read_error` → `test_read_file_returns_none_for_directory`).
- **Cleanup**: removed an unreachable `try/except` in `_get_cpu_cores` (the wrapped `dict.get()` calls cannot raise).
- **Makefile**: fixed broken paths (`docker compose.X.yml` → `docker-compose.X.yml`); `make test`, `make dev`, `make debug` were failing with "no such file" before this commit.
- **Skills**: `.claude/skills/` with `git-conventions`, `test-discipline`, and `dev-workflow` adapted to this project.

## Test plan

- [ ] CI passes (full suite under `dev/docker-compose.test.yml`).
- [ ] `make test`, `make dev`, `make debug` parse and start the right compose file.
- [ ] On deploy: `docker exec grafana id` shows `uid=472`; the SQLite datasource plugin still loads; existing dashboards persist (the `grafana-init` chown is non-destructive on existing data).
- [ ] Docker Pulls badge renders on github.com README (it shows the live count from Docker Hub).
- [ ] Spot-check: a video whose `SYNOINDEX_MEDIA_INFO` is unreadable due to permissions now logs the actual `PermissionError` instead of the misleading "not found" warning.