### PR TITLE
docs: update docs to reflect transcoding-settings-to-db migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This tool automatically re-transcodes them to modern formats with hardware accel
 
 1. **Create directory structure** on your NAS (e.g. `/volume1/docker/photo/photo-video-enhancer/`)
 2. **Copy `docker-compose.yml`** and edit volume mounts to point to your photo directories
-3. **Create `.env`** from `env.example` and adjust settings (codec, resolution, bitrate, etc.)
+3. **Create `.env`** from `env.example` and set the required dashboard credentials (`DASHBOARD_PASSWORD`, `DASHBOARD_SECRET_KEY`). Transcoding settings (codec, resolution, bitrate, etc.) are configured via the dashboard at runtime.
 4. **Deploy** via Synology Container Manager or `docker compose up -d`
 
 For step-by-step instructions and the full environment variables reference, see the **[Configuration Guide](https://github.com/cibrandocampo/synology-photos-video-enhancer/blob/master/docs/configuration.md)**.
@@ -118,7 +118,7 @@ For detailed development instructions, see the [Development Guide](https://githu
 ```
 src/
 ├── application/          # Application logic (use cases)
-├── controllers/         # Controllers (CLI interface)
+├── controllers/         # Controllers (entry-point orchestration)
 ├── domain/              # Domain models and business logic
 │   ├── constants/      # Enums and constants
 │   ├── models/         # Domain models

--- a/src/README.md
+++ b/src/README.md
@@ -51,12 +51,10 @@ src/
 
 ### `controllers/main_controller.py` - Main Controller
 
-**Responsibility**: Parse CLI arguments and launch use case
+**Responsibility**: Entry-point orchestration — launch the use case
 
-- Parses command-line arguments (`--dry-run`, `--verbose`, `--only-new`)
-- Validates input format
 - Launches the use case
-- Displays output
+- Returns the result
 
 **The controller does NOT**:
 - List directories
@@ -240,17 +238,9 @@ Each module has one clear responsibility:
 python main.py
 ```
 
-### CLI Options
-
-```bash
-python main.py --dry-run      # Show what would be done
-python main.py --verbose      # Enable verbose output
-python main.py --only-new      # Only process new videos
-```
-
 ## Configuration
 
-Configuration is loaded **only from environment variables**. See `env.example` in the root directory for all available variables.
+Infrastructure settings are loaded from environment variables. See `env.example` in the root directory for the full reference.
 
 ### Main Environment Variables
 
@@ -258,29 +248,15 @@ Configuration is loaded **only from environment variables**. See `env.example` i
 - `MEDIA_APP_PATH` - Path inside container where media is mounted (default: `/media`)
 - `DATABASE_APP_PATH` - Path inside container where database is stored (default: `data/transcodings.db`)
 
-**Transcoding Resources:**
-- `HW_TRANSCODING` - Enable hardware transcoding (True/False, default: True)
-- `EXECUTION_THREADS` - Number of threads for FFmpeg (default: 2)
+**Scheduling:**
 - `STARTUP_DELAY` - Minutes to wait before first execution (default: 30)
 - `EXECUTION_INTERVAL` - Minutes between periodic executions (default: 240)
-
-**Video Settings:**
-- `VIDEO_CODEC` - Video codec: h264, hevc, mpeg4, etc. (default: h264)
-- `VIDEO_BITRATE` - Video bitrate in kbps (default: 2048)
-- `VIDEO_RESOLUTION` - Resolution: 144p, 240p, 360p, 480p, 720p, 1080p, etc. (default: 720p)
-- `VIDEO_PROFILE` - Video profile (codec-specific, optional)
-
-**Audio Settings:**
-- `AUDIO_CODEC` - Audio codec: aac, mp3, ac3, etc. (default: aac)
-- `AUDIO_BITRATE` - Audio bitrate in kbps (default: 128)
-- `AUDIO_CHANNELS` - Number of audio channels: 1 or 2 (default: 1)
-- `AUDIO_PROFILE` - Audio profile (only for AAC, optional)
 
 **Logger:**
 - `LOGGER_NAME` - Logger name (default: synology-photos-video-enhancer)
 - `LOGGER_LEVEL` - Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL (default: INFO)
 
-For a complete list of all environment variables and their descriptions, see `env.example` in the root directory.
+**Transcoding settings** (codec, bitrate, resolution, threads, hardware acceleration, etc.) are stored in the SQLite database and managed at runtime via the built-in dashboard. They are not read from environment variables.
 
 ## Adding New Features
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -125,7 +125,4 @@ Common fixtures are defined in `conftest.py`:
 
 ## Coverage Goals
 
-- Domain layer: 100% coverage (pure business logic)
-- Application layer: >90% coverage (use cases)
-- Infrastructure layer: >80% coverage (adapters)
-- Controllers: >80% coverage
+- All layers: ≥95% coverage (enforced — no file may fall below this floor)


### PR DESCRIPTION
## Summary

- **README**: Quick Start step 3 now points to dashboard credentials instead of codec/resolution/bitrate env vars; `controllers/` label corrected from "CLI interface" to "entry-point orchestration"
- **src/README**: Removed stale CLI options section (`--dry-run`, `--verbose`, `--only-new`) and the 10 transcoding env vars; added note that transcoding settings live in the DB and are managed via the dashboard
- **tests/README**: Replaced per-layer coverage floors (80%/90%) with the enforced ≥95% rule

## Test plan

- [ ] Docs-only change — no code modified, no tests required