### PR TITLE
refactor(config): rename DASHBOARD_* env vars to WEB_*

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ This tool automatically re-transcodes them to modern formats with hardware accel
 
 1. **Create directory structure** on your NAS (e.g. `/volume1/docker/photo/photo-video-enhancer/`)
 2. **Copy `docker-compose.yml`** and edit volume mounts to point to your photo directories
-3. **Create `.env`** from `env.example` and set the required dashboard credentials (`DASHBOARD_PASSWORD`, `DASHBOARD_SECRET_KEY`). Transcoding settings (codec, resolution, bitrate, etc.) are configured via the dashboard at runtime.
+3. **Create `.env`** from `env.example` and set the required dashboard credentials (`WEB_PASSWORD`, `WEB_SECRET_KEY`). Transcoding settings (codec, resolution, bitrate, etc.) are configured via the dashboard at runtime.
 4. **Deploy** via Synology Container Manager or `docker compose up -d`
 
 For step-by-step instructions and the full environment variables reference, see the **[Configuration Guide](https://github.com/cibrandocampo/synology-photos-video-enhancer/blob/master/docs/configuration.md)**.
@@ -97,7 +97,7 @@ View logs with `docker logs synology-photos-video-enhancer` or via Container Man
 
 The container ships with a built-in, server-rendered dashboard that runs alongside the scheduler in the same process — no extra container, no JavaScript, no external service.
 
-- **Access**: `http://<NAS-ip>:${DASHBOARD_PORT:-9200}/`. Recommended setup: put it behind DSM's reverse proxy with TLS termination.
+- **Access**: `http://<NAS-ip>:${WEB_PORT:-9200}/`. Recommended setup: put it behind DSM's reverse proxy with TLS termination.
 - **What it shows**: total transcodings, counts per status, success rate, codec distribution, resolution distribution, the latest 5 transcodings, and the top 5 errors. HTML tables and CSS bars only.
 
 **Endpoints:**
@@ -111,7 +111,7 @@ The container ships with a built-in, server-rendered dashboard that runs alongsi
 | `POST` | `/login` | none | Submit credentials |
 | `GET`  | `/logout` | required | Clear the session and redirect to `/login` |
 
-**Authentication.** Single user. Username is `DASHBOARD_USER` (defaults to `admin`); password is `DASHBOARD_PASSWORD` and is **required** — the app refuses to start if it is unset or empty. The session cookie is HMAC-signed with `DASHBOARD_SECRET_KEY` (also required). Generate the secret with:
+**Authentication.** Single user. Username is `WEB_USER` (defaults to `admin`); password is `WEB_PASSWORD` and is **required** — the app refuses to start if it is unset or empty. The session cookie is HMAC-signed with `WEB_SECRET_KEY` (also required). Generate the secret with:
 
 ```bash
 python -c "import secrets; print(secrets.token_urlsafe(32))"
@@ -124,10 +124,10 @@ For the full list of dashboard env vars (port, cookie flags, etc.) see the **[Co
 If you were using the previous Grafana setup:
 
 - **Pull the new image** and redeploy.
-- **Edit `.env`** — add `DASHBOARD_USER`, `DASHBOARD_PASSWORD` (required), and `DASHBOARD_SECRET_KEY` (required, generate with the `python -c` command above). Optionally set `DASHBOARD_PORT` and `DASHBOARD_COOKIE_SECURE`. Remove the now-defunct `GRAFANA_*` vars.
+- **Edit `.env`** — add `WEB_USER`, `WEB_PASSWORD` (required), and `WEB_SECRET_KEY` (required, generate with the `python -c` command above). Optionally set `WEB_PORT` and `WEB_COOKIE_SECURE`. Remove the now-defunct `GRAFANA_*` vars.
 - **Update `docker-compose.yml`** — the new template no longer contains the `grafana` or `grafana-init` services. If you copied the previous compose locally, drop those service blocks yourself.
 - **Optionally delete `./grafana-data`** on the host — leftover state from the old Grafana container; it is no longer used.
-- **Update DSM's reverse proxy** entry: replace the rule that pointed at port `3000` (Grafana) with one pointing at `${DASHBOARD_PORT:-9200}` (internal dashboard).
+- **Update DSM's reverse proxy** entry: replace the rule that pointed at port `3000` (Grafana) with one pointing at `${WEB_PORT:-9200}` (internal dashboard).
 
 ## Development
 

--- a/dev/docker-compose.dev.yml
+++ b/dev/docker-compose.dev.yml
@@ -17,7 +17,7 @@ services:
       # Mount source code for live development (changes reflect immediately)
       - ../src:/app
     ports:
-      - "${DASHBOARD_PORT:-9200}:${DASHBOARD_PORT:-9200}"
+      - "${WEB_PORT:-9200}:${WEB_PORT:-9200}"
     # Enable hardware acceleration (VAAPI/QSV) if available
     devices:
       - /dev/dri:/dev/dri

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - path: .env
         required: false
     ports:
-      - "${DASHBOARD_PORT:-9200}:${DASHBOARD_PORT:-9200}"
+      - "${WEB_PORT:-9200}:${WEB_PORT:-9200}"
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${DASHBOARD_PORT:-9200}/healthz').read()"]
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://127.0.0.1:${WEB_PORT:-9200}/healthz').read()"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,8 +39,8 @@ The application needs access to all photo directories. You must mount:
 
 Copy `env.example` to `.env` next to `docker-compose.yml` and adjust values for your installation. Two dashboard variables are **required** before the container will start:
 
-- `DASHBOARD_PASSWORD` — pick any non-empty value.
-- `DASHBOARD_SECRET_KEY` — generate one with:
+- `WEB_PASSWORD` — pick any non-empty value.
+- `WEB_SECRET_KEY` — generate one with:
 
   ```bash
   python -c "import secrets; print(secrets.token_urlsafe(32))"
@@ -57,11 +57,11 @@ All other variables have sensible defaults (see the table below).
 | **Database Configuration** |
 | `DATABASE_HOST_PATH` | `./data` | Path on the HOST where the database directory is located. The SQLite database file will be stored in this location. Typically in a `volumes` or `volumes/data/` folder |
 | **Dashboard Configuration** |
-| `DASHBOARD_PORT` | `9200` | Port where the internal dashboard listens (host and container) |
-| `DASHBOARD_USER` | `admin` | Username for the single dashboard user |
-| `DASHBOARD_PASSWORD` | _(none)_ | Password for the single dashboard user. **Required** — the app refuses to start if this is empty |
-| `DASHBOARD_SECRET_KEY` | _(none)_ | HMAC key for signing the session cookie. **Required** — generate with `python -c "import secrets; print(secrets.token_urlsafe(32))"` |
-| `DASHBOARD_COOKIE_SECURE` | `false` | Set to `true` if the dashboard serves HTTPS directly. Leave `false` when DSM's reverse proxy terminates TLS (the typical Synology setup) |
+| `WEB_PORT` | `9200` | Port where the internal dashboard listens (host and container) |
+| `WEB_USER` | `admin` | Username for the single dashboard user |
+| `WEB_PASSWORD` | _(none)_ | Password for the single dashboard user. **Required** — the app refuses to start if this is empty |
+| `WEB_SECRET_KEY` | _(none)_ | HMAC key for signing the session cookie. **Required** — generate with `python -c "import secrets; print(secrets.token_urlsafe(32))"` |
+| `WEB_COOKIE_SECURE` | `false` | Set to `true` if the dashboard serves HTTPS directly. Leave `false` when DSM's reverse proxy terminates TLS (the typical Synology setup) |
 | **Logger Configuration** |
 | `LOGGER_NAME` | `video-enhancer` | Logger name (used in log messages) |
 | `LOGGER_LEVEL` | `INFO` | Log level: `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
@@ -74,10 +74,10 @@ All other variables have sensible defaults (see the table below).
 
 ## Dashboard
 
-The container runs an internal HTTP dashboard on `${DASHBOARD_PORT:-9200}`, exposed by `docker-compose.yml`. After `docker compose up -d`, the dashboard is reachable at:
+The container runs an internal HTTP dashboard on `${WEB_PORT:-9200}`, exposed by `docker-compose.yml`. After `docker compose up -d`, the dashboard is reachable at:
 
 ```
-http://<NAS-ip>:${DASHBOARD_PORT:-9200}/
+http://<NAS-ip>:${WEB_PORT:-9200}/
 ```
 
 It serves HTML at `/`, JSON at `/api/stats` (same payload), and an unauthenticated `{"status":"ok"}` probe at `/healthz`. The `healthcheck:` block in `docker-compose.yml` already targets `/healthz`, so `docker ps` will report the container as `healthy` once the dashboard is reachable.

--- a/env.example
+++ b/env.example
@@ -27,22 +27,22 @@ DATABASE_HOST_PATH=/volume1/docker/photo/photo-video-enhancer/volumes/database
 # ============================================
 # Port where the internal dashboard listens (host and container).
 # Default: 9200
-DASHBOARD_PORT=9200
+WEB_PORT=9200
 
 # Username for the single dashboard user.
-DASHBOARD_USER=admin
+WEB_USER=admin
 
 # Password for the single dashboard user. REQUIRED — the app fails to start
 # if this is empty.
-DASHBOARD_PASSWORD=CHANGEME
+WEB_PASSWORD=CHANGEME
 
 # HMAC key for signing the session cookie. REQUIRED — generate one with:
 #   python -c "import secrets; print(secrets.token_urlsafe(32))"
-DASHBOARD_SECRET_KEY=
+WEB_SECRET_KEY=
 
 # Set to true if the dashboard serves HTTPS directly (rare on Synology, where
 # DSM's reverse proxy terminates TLS). Default: false.
-DASHBOARD_COOKIE_SECURE=false
+WEB_COOKIE_SECURE=false
 
 # ============================================
 # ADVANCED / DEVELOPMENT CONFIGURATION

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -200,7 +200,7 @@ cp env.example .env</code></pre>
               </tr>
               <tr class="bg-slate-900/40">
                 <td class="px-5 py-4 font-mono text-enhancer-300 align-top whitespace-nowrap">
-                  DASHBOARD_PASSWORD<span class="ml-1 text-red-400 text-xs align-super">✱</span>
+                  WEB_PASSWORD<span class="ml-1 text-red-400 text-xs align-super">✱</span>
                 </td>
                 <td class="px-5 py-4 text-slate-300">
                   Password for the dashboard login. The container refuses to start if this is empty.
@@ -208,7 +208,7 @@ cp env.example .env</code></pre>
               </tr>
               <tr class="bg-slate-900/40">
                 <td class="px-5 py-4 font-mono text-enhancer-300 align-top whitespace-nowrap">
-                  DASHBOARD_SECRET_KEY<span class="ml-1 text-red-400 text-xs align-super">✱</span>
+                  WEB_SECRET_KEY<span class="ml-1 text-red-400 text-xs align-super">✱</span>
                 </td>
                 <td class="px-5 py-4 text-slate-300">
                   HMAC key for signing session cookies. Generate it once and keep it:
@@ -218,11 +218,11 @@ cp env.example .env</code></pre>
                 </td>
               </tr>
               <tr>
-                <td class="px-5 py-4 font-mono text-slate-300 align-top whitespace-nowrap">DASHBOARD_PORT</td>
+                <td class="px-5 py-4 font-mono text-slate-300 align-top whitespace-nowrap">WEB_PORT</td>
                 <td class="px-5 py-4 text-slate-400">Port where the dashboard is accessible. Default: <code class="text-slate-300">9200</code></td>
               </tr>
               <tr>
-                <td class="px-5 py-4 font-mono text-slate-300 align-top whitespace-nowrap">DASHBOARD_USER</td>
+                <td class="px-5 py-4 font-mono text-slate-300 align-top whitespace-nowrap">WEB_USER</td>
                 <td class="px-5 py-4 text-slate-400">Dashboard login username. Default: <code class="text-slate-300">admin</code></td>
               </tr>
               <tr>

--- a/src/infrastructure/config/config.py
+++ b/src/infrastructure/config/config.py
@@ -17,11 +17,11 @@ from infrastructure.utils import to_int
 
 
 _DASHBOARD_FIELD_TO_ENV = {
-    "port": "DASHBOARD_PORT",
-    "user": "DASHBOARD_USER",
-    "password": "DASHBOARD_PASSWORD",
-    "secret_key": "DASHBOARD_SECRET_KEY",
-    "cookie_secure": "DASHBOARD_COOKIE_SECURE",
+    "port": "WEB_PORT",
+    "user": "WEB_USER",
+    "password": "WEB_PASSWORD",
+    "secret_key": "WEB_SECRET_KEY",
+    "cookie_secure": "WEB_COOKIE_SECURE",
 }
 
 
@@ -140,14 +140,14 @@ class Config:
         )
 
     def _load_dashboard(self):
-        """Hard-fails if DASHBOARD_PASSWORD or DASHBOARD_SECRET_KEY are missing/empty."""
+        """Hard-fails if WEB_PASSWORD or WEB_SECRET_KEY are missing/empty."""
         self._ensure_app_config()
 
-        port = to_int(os.getenv("DASHBOARD_PORT"), default=9200)
-        user = os.getenv("DASHBOARD_USER", "admin")
-        password = os.getenv("DASHBOARD_PASSWORD", "")
-        secret_key = os.getenv("DASHBOARD_SECRET_KEY", "")
-        cookie_secure = os.getenv("DASHBOARD_COOKIE_SECURE", "false").lower() in ("true", "1", "yes")
+        port = to_int(os.getenv("WEB_PORT"), default=9200)
+        user = os.getenv("WEB_USER", "admin")
+        password = os.getenv("WEB_PASSWORD", "")
+        secret_key = os.getenv("WEB_SECRET_KEY", "")
+        cookie_secure = os.getenv("WEB_COOKIE_SECURE", "false").lower() in ("true", "1", "yes")
 
         try:
             self._app_config.dashboard = DashboardConfig(

--- a/tests/infrastructure/test_config.py
+++ b/tests/infrastructure/test_config.py
@@ -77,8 +77,8 @@ class TestDashboardConfig:
     @staticmethod
     def _env(**overrides):
         env = {
-            "DASHBOARD_PASSWORD": "secret",
-            "DASHBOARD_SECRET_KEY": "key123",
+            "WEB_PASSWORD": "secret",
+            "WEB_SECRET_KEY": "key123",
         }
         env.update(overrides)
         return env
@@ -94,53 +94,53 @@ class TestDashboardConfig:
             assert dashboard.cookie_secure is False
 
     def test_dashboard_password_missing_raises(self):
-        with patch.dict(os.environ, {"DASHBOARD_SECRET_KEY": "key123"}, clear=True):
+        with patch.dict(os.environ, {"WEB_SECRET_KEY": "key123"}, clear=True):
             with pytest.raises(RuntimeError) as exc_info:
                 _ = Config.load().dashboard
 
             message = str(exc_info.value)
             assert message.startswith("Dashboard configuration error: ")
-            assert "DASHBOARD_PASSWORD" in message
+            assert "WEB_PASSWORD" in message
 
     def test_dashboard_password_empty_raises(self):
-        env = {"DASHBOARD_PASSWORD": "", "DASHBOARD_SECRET_KEY": "key123"}
+        env = {"WEB_PASSWORD": "", "WEB_SECRET_KEY": "key123"}
         with patch.dict(os.environ, env, clear=True):
             with pytest.raises(RuntimeError) as exc_info:
                 _ = Config.load().dashboard
 
             message = str(exc_info.value)
             assert message.startswith("Dashboard configuration error: ")
-            assert "DASHBOARD_PASSWORD" in message
+            assert "WEB_PASSWORD" in message
 
     def test_dashboard_secret_key_missing_raises(self):
-        with patch.dict(os.environ, {"DASHBOARD_PASSWORD": "secret"}, clear=True):
+        with patch.dict(os.environ, {"WEB_PASSWORD": "secret"}, clear=True):
             with pytest.raises(RuntimeError) as exc_info:
                 _ = Config.load().dashboard
 
             message = str(exc_info.value)
             assert message.startswith("Dashboard configuration error: ")
-            assert "DASHBOARD_SECRET_KEY" in message
+            assert "WEB_SECRET_KEY" in message
 
     def test_dashboard_custom_port(self):
-        with patch.dict(os.environ, self._env(DASHBOARD_PORT="9300"), clear=True):
+        with patch.dict(os.environ, self._env(WEB_PORT="9300"), clear=True):
             assert Config.load().dashboard.port == 9300
 
     def test_dashboard_custom_user(self):
-        with patch.dict(os.environ, self._env(DASHBOARD_USER="monitor"), clear=True):
+        with patch.dict(os.environ, self._env(WEB_USER="monitor"), clear=True):
             assert Config.load().dashboard.user == "monitor"
 
     def test_dashboard_cookie_secure_truthy(self):
-        with patch.dict(os.environ, self._env(DASHBOARD_COOKIE_SECURE="true"), clear=True):
+        with patch.dict(os.environ, self._env(WEB_COOKIE_SECURE="true"), clear=True):
             assert Config.load().dashboard.cookie_secure is True
 
     def test_dashboard_port_out_of_range_raises(self):
-        with patch.dict(os.environ, self._env(DASHBOARD_PORT="70000"), clear=True):
+        with patch.dict(os.environ, self._env(WEB_PORT="70000"), clear=True):
             with pytest.raises(RuntimeError) as exc_info:
                 _ = Config.load().dashboard
 
             message = str(exc_info.value)
             assert message.startswith("Dashboard configuration error: ")
-            assert "DASHBOARD_PORT" in message
+            assert "WEB_PORT" in message
 
     def test_dashboard_validation_error_unknown_field_raises_generic_message(self):
         """Covers the else branch of offending_text when no field maps to an env var name."""
@@ -169,7 +169,7 @@ class TestDashboardConfig:
 
     def test_log_config_does_not_log_password_or_secret(self):
         """log_config must mention port/user but never the password or secret."""
-        env = self._env(DASHBOARD_PASSWORD="topsecretpass", DASHBOARD_SECRET_KEY="topsecretkey")
+        env = self._env(WEB_PASSWORD="topsecretpass", WEB_SECRET_KEY="topsecretkey")
         with patch.dict(os.environ, env, clear=True):
             mock_logger = Mock()
             Config.load().log_config(mock_logger, TranscodingSettings())


### PR DESCRIPTION
## Summary

The web interface serves both a stats dashboard and a settings/configuration panel, so `DASHBOARD_*` was misleading. `WEB_*` better reflects the actual scope.

| Old | New |
|-----|-----|
| `DASHBOARD_PORT` | `WEB_PORT` |
| `DASHBOARD_USER` | `WEB_USER` |
| `DASHBOARD_PASSWORD` | `WEB_PASSWORD` |
| `DASHBOARD_SECRET_KEY` | `WEB_SECRET_KEY` |
| `DASHBOARD_COOKIE_SECURE` | `WEB_COOKIE_SECURE` |

## ⚠️ Breaking change

Existing deployments must rename these variables in their `.env` file before upgrading.

## Files changed

`config.py`, `docker-compose.yml`, `dev/docker-compose.dev.yml`, `env.example`, `docs/configuration.md`, `README.md`, `site/src/pages/index.astro`, `tests/infrastructure/test_config.py`

## Test plan

- [x] 430 tests pass locally