### PR TITLE
fix(docker): use simple env_file syntax compatible with Compose v2.20

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,7 @@ services:
       dockerfile: Dockerfile
     container_name: synology-photos-video-enhancer
     env_file:
-      - path: .env
-        required: false
+      - .env
     ports:
       - "${DASHBOARD_PORT:-9200}:${DASHBOARD_PORT:-9200}"
     healthcheck:


### PR DESCRIPTION
## Problem

Synology Container Manager ships Docker Compose v2.20, which does not support the extended `env_file` map form (`path` / `required` keys) — it rejects the `docker-compose.yml` with a validation error at startup.

The extended syntax requires Compose v2.24+.

## Fix

Replace the map form with the simple list form, which works on all supported versions:

```yaml
# before
env_file:
  - path: .env
    required: false

# after
env_file:
  - .env
```

## Test plan
- [ ] `docker-compose config` validates without errors on Compose v2.20
- [ ] Container Manager on Synology can start the stack without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)