### PR TITLE
fix(dashboard): mobile KPI overflow, build version and prerequisites

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,10 +38,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event_name == 'release' && github.event.release.tag_name || github.ref }}
-      
+          # Full history + tags: git describe needs them to resolve a version.
+          fetch-depth: 0
+
+      - name: Compute app version
+        id: version
+        run: echo "value=$(git describe --tags --always --abbrev=5)" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -71,6 +77,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             PY_IMAGE=python:3.14-slim-bookworm
+            APP_VERSION=${{ steps.version.outputs.value }}
       
       - name: Update Docker Hub description
         uses: peter-evans/dockerhub-description@v5

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,4 +43,9 @@ WORKDIR /app
 EXPOSE 9200
 COPY ./src /app
 
+# Version shown in the dashboard footer. CI passes the output of
+# `git describe --tags --always --abbrev=5`; local builds keep "dev".
+ARG APP_VERSION=dev
+ENV APP_VERSION=$APP_VERSION
+
 ENTRYPOINT ["python", "main.py"]

--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ This tool automatically re-transcodes them to modern formats with hardware accel
 
 ## Prerequisites
 
-- APP: Synology Photos > 1.8
-- SO: Synology DSM > 7.1
-- Docker: Version > 20 | It is recommended to use Synology's "Container Manager" as it greatly facilitates management. Version > 24
-- Intel CPUs Only: SynoCli Video Drivers package > 1.3 | Provides video driver support for Intel GPU acceleration (DSM6-7), including OpenCL (DSM7.1+ only). **Note:** AMD CPUs have drivers included by default, this package is only required for Intel processors. Available from [SynoCommunity](https://synocommunity.com/).
+- APP: Synology Photos 1.9.1 or later
+- SO: Synology DSM 7.3.2 or later
+- Docker: Version 24.0.2 or later, via Synology's "Container Manager" (recommended, as it greatly facilitates management)
+- Intel CPUs Only: SynoCli Video Drivers package 1.5.8 or later | Provides video driver support for Intel GPU acceleration, including OpenCL. **Note:** AMD CPUs have drivers included by default, this package is only required for Intel processors. Available from [SynoCommunity](https://synocommunity.com/).
 
 ## Quick Start
 

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -60,7 +60,7 @@ const faqItems = [
   },
   {
     q: 'What hardware do I need?',
-    a: 'Any Synology NAS running DSM 7.1+ with Docker or Container Manager. Intel iGPU unlocks QSV (requires the SynoCli Video Drivers package from SynoCommunity). AMD or Intel GPU with a DRI device unlocks VAAPI. ARM SoCs (DS220+ class) get V4L2M2M for free.',
+    a: 'Any Synology NAS running DSM 7.3.2+ with Container Manager 24.0.2+ (and Synology Photos 1.9.1+). Intel iGPU unlocks QSV (requires the SynoCli Video Drivers package 1.5.8+ from SynoCommunity). AMD or Intel GPU with a DRI device unlocks VAAPI. ARM SoCs (DS220+ class) get V4L2M2M for free.',
   },
   {
     q: 'What if I have no GPU or hardware acceleration?',

--- a/src/infrastructure/version.py
+++ b/src/infrastructure/version.py
@@ -1,0 +1,12 @@
+"""Build-time application version.
+
+CI injects the output of `git describe --tags --always --abbrev=5` as the
+`APP_VERSION` build arg, which the Dockerfile promotes to an env var. Local
+and development builds get "dev", so an unversioned image is obvious at a
+glance instead of masquerading as a release.
+"""
+
+import os
+
+
+APP_VERSION = os.getenv("APP_VERSION", "dev")

--- a/src/infrastructure/web/app.py
+++ b/src/infrastructure/web/app.py
@@ -14,6 +14,7 @@ from application.settings_use_case import SettingsUseCase
 from domain.models.app_config import DashboardConfig
 from domain.ports.hardware_info import HardwareInfo
 from domain.ports.logger import AppLogger
+from infrastructure.version import APP_VERSION
 from infrastructure.web.auth import RedirectToLoginRequired
 from infrastructure.web.i18n import Translations
 from infrastructure.web.security_headers import SecurityHeadersMiddleware
@@ -54,6 +55,9 @@ def create_app(
         return RedirectResponse(url="/login", status_code=302)
 
     app.state.templates = Jinja2Templates(directory=str(_TEMPLATES_DIR))
+    # Global so the base layout can render the footer without every router
+    # having to thread the version through its template context.
+    app.state.templates.env.globals["app_version"] = APP_VERSION
     app.state.use_case = use_case
     app.state.settings_use_case = settings_use_case
     app.state.retranscode_use_case = retranscode_use_case

--- a/src/infrastructure/web/static/style.css
+++ b/src/infrastructure/web/static/style.css
@@ -292,6 +292,14 @@ body {
   padding: 2rem;
 }
 
+.app-version {
+  text-align: center;
+  font-size: 0.7rem;
+  color: var(--c-text-3);
+  margin: 1.5rem 0 0;
+  font-variant-numeric: tabular-nums;
+}
+
 /* ========================================
    KPI groups
    ======================================== */

--- a/src/infrastructure/web/static/style.css
+++ b/src/infrastructure/web/static/style.css
@@ -323,6 +323,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  /* Long labels must not widen the grid track and overflow the viewport */
+  min-width: 0;
 }
 
 .kpi-header {
@@ -330,6 +332,7 @@ body {
   align-items: center;
   gap: 0.4rem;
   color: var(--c-text-3);
+  min-width: 0;
 }
 
 .kpi-label {
@@ -337,6 +340,9 @@ body {
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.08em;
+  min-width: 0;
+  /* Break long single words (e.g. "TRANSCODIFICACIÓN") instead of clipping */
+  overflow-wrap: anywhere;
 }
 
 .kpi-value {

--- a/src/infrastructure/web/static/sw.js
+++ b/src/infrastructure/web/static/sw.js
@@ -1,4 +1,4 @@
-const CACHE = 'video-enhancer-v2';
+const CACHE = 'video-enhancer-v3';
 const STATIC = [
   '/static/style.css',
   '/static/icons.svg',

--- a/src/infrastructure/web/templates/settings.html
+++ b/src/infrastructure/web/templates/settings.html
@@ -384,6 +384,8 @@
 
   </div><!-- #compat-tables -->
 
+  <p class="app-version">{{ app_version }}</p>
+
 </main>
 <script src="/static/settings.js?v=3"></script>
 {% endblock %}

--- a/tests/controllers/dashboard/test_settings_router.py
+++ b/tests/controllers/dashboard/test_settings_router.py
@@ -79,6 +79,12 @@ class TestSettingsGet:
         assert response.headers["content-type"].startswith("text/html")
         assert "settings" in response.text.lower()
 
+    def test_page_ends_with_the_build_version(self, client):
+        _login(client)
+        response = client.get("/settings")
+
+        assert '<p class="app-version">dev</p>' in response.text
+
     def test_saved_query_param_shows_confirmation(self, client):
         _login(client)
         response = client.get("/settings?saved=1")

--- a/tests/infrastructure/test_version.py
+++ b/tests/infrastructure/test_version.py
@@ -1,0 +1,24 @@
+"""Tests for the build-time version constant."""
+
+import importlib
+
+import infrastructure.version
+
+
+class TestAppVersion:
+    def test_defaults_to_dev_without_build_arg(self, monkeypatch):
+        monkeypatch.delenv("APP_VERSION", raising=False)
+        module = importlib.reload(infrastructure.version)
+
+        assert module.APP_VERSION == "dev"
+
+    def test_reads_the_value_injected_by_ci(self, monkeypatch):
+        monkeypatch.setenv("APP_VERSION", "v4.2.1-2-gbd6bb")
+        module = importlib.reload(infrastructure.version)
+
+        assert module.APP_VERSION == "v4.2.1-2-gbd6bb"
+
+    def teardown_method(self):
+        # The constant is read at import time and cached by other modules;
+        # restore the process-wide default so test order stays irrelevant.
+        importlib.reload(infrastructure.version)


### PR DESCRIPTION
## Summary

- Stop long KPI labels from dragging the whole dashboard past the viewport on mobile. Grid items default to `min-width: auto`, so the min-content width of an unbreakable label (`TRANSCODIFICACIÓN` in gl/es) widened the `1fr` track: at a 390px viewport the document measured 469px, clipping the second KPI card and the navbar. Fixed with `min-width: 0` on `.kpi`/`.kpi-header` and `overflow-wrap: anywhere` on `.kpi-label`.
- Show the build version at the end of the settings page. `APP_VERSION` is injected as a Docker build arg, promoted to an env var and read once into `infrastructure/version.py`; `build-push.yml` computes it with `git describe --tags --always --abbrev=5`. Local builds keep `dev`.
- Bump the service worker cache to `video-enhancer-v3`. `/static/` is served cache-first with no revalidation, so installed PWAs keep serving the previous `style.css` until the cache name changes — without this, neither CSS change above reaches existing users.
- Raise the documented prerequisites to the currently supported versions: Synology Photos 1.9.1+, DSM 7.3.2+, Container Manager 24.0.2+, SynoCli Video Drivers 1.5.8+. Drops the stale `Docker > 20` floor and the DSM 6-7 / OpenCL caveats that no longer apply.

## Notes

> **Note**: `build-push.yml` needed `fetch-depth: 0` on the build job checkout. The default shallow clone carries no tags, so `git describe` would have resolved to a bare commit hash and the displayed version would never have shown a release tag.

> **Note**: the version is exposed as a Jinja global rather than added to each router's template context, so future views get it without having to thread it through — and it is rendered only on the settings page, matching where `ovh-dyndns-client` and `nudge` put it.

## Test plan

- [x] Dockerized backend suite: `make test` — 465 passed, including new coverage for the `APP_VERSION` default/override and for the version line rendering in the settings page.
- [x] Layout verified with Playwright against a running container at 390px and 360px in gl/es/en: `document.scrollWidth` matches the viewport on login, dashboard and settings (was 469px at 390px before the fix).
- [x] Settings page renders the injected version centered at 0.7rem in `--c-text-3`; `.main-content` still 1200px on desktop and the navbar still sticks on scroll.
- [ ] Build the image with a version and confirm it surfaces: `docker build --build-arg APP_VERSION=$(git describe --tags --always --abbrev=5) -t ve:verify .`, run it, open `/settings` and check the footer line.
- [ ] Confirm on a real Synology install that an already-installed PWA picks up the new CSS after the service worker cache bump.